### PR TITLE
release: add workflow_dispatch ref input, wire to checkout and tag_name

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,6 +7,11 @@ on:
   release:
     types: [published]
   workflow_dispatch:
+    inputs:
+      ref:
+        description: "Git ref (tag/branch/SHA) to build and release"
+        required: true
+        type: string
 
 jobs:
   build:
@@ -28,6 +33,8 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event_name == 'workflow_dispatch' && inputs.ref || github.ref }}
       - uses: dtolnay/rust-toolchain@stable
         with:
           toolchain: 1.90.0
@@ -181,5 +188,6 @@ jobs:
           files: |
             dist/github-mcp-*
             dist/SHA256SUMS.txt
+          tag_name: ${{ github.event_name == 'workflow_dispatch' && inputs.ref || github.event.release.tag_name }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Implements Issue #28: add workflow_dispatch input and wire it to checkout and tag_name for Release Binaries so we can build/attach for a specified ref while using the workflow on main.

Changes:
- Add inputs.ref under on.workflow_dispatch (required string)
- Update actions/checkout to select ref: `${{ github.event_name == 'workflow_dispatch' && inputs.ref || github.ref }}`
- Update Upload release assets to set tag_name similarly: `${{ github.event_name == 'workflow_dispatch' && inputs.ref || github.event.release.tag_name }}`

Context: see #24 and #25 for related workflow improvements.

Notes:
- No behavior change for `release` event runs; only affects manual dispatch.
- Please verify CI on the branch and try a manual dispatch with a tag or branch to confirm.
