### PR TITLE
ci: Release Binaries supports manual tag release (Issue #30)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,6 +7,11 @@ on:
   release:
     types: [published]
   workflow_dispatch:
+    inputs:
+      tag:
+        description: "Tag to release"
+        required: true
+        type: string
 
 jobs:
   build:
@@ -28,6 +33,8 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event_name == 'workflow_dispatch' && inputs.tag || github.ref }}
       - uses: dtolnay/rust-toolchain@stable
         with:
           toolchain: 1.90.0
@@ -106,6 +113,7 @@ jobs:
   release:
     name: Attach to Release
     needs: build
+    if: github.event_name == 'release' || (github.event_name == 'workflow_dispatch' && inputs.tag != '')
     runs-on: ubuntu-latest
     steps:
       - uses: actions/download-artifact@v4
@@ -178,6 +186,8 @@ jobs:
       - name: Upload release assets
         uses: softprops/action-gh-release@v2
         with:
+          tag_name: ${{ github.event_name == 'workflow_dispatch' && inputs.tag || '' }}
+          overwrite: true
           files: |
             dist/github-mcp-*
             dist/SHA256SUMS.txt


### PR DESCRIPTION
Implements the fix for Release Binaries workflow as per Issue #30.

Changes in .github/workflows/release.yml only:
- Add workflow_dispatch with required string input `tag`.
- Checkout uses ref `${{ github.event_name == 'workflow_dispatch' && inputs.tag || github.ref }}`.
- Ensure the release job runs when event is `release` or manual with tag present: `if: github.event_name == 'release' || (github.event_name == 'workflow_dispatch' && inputs.tag != '')`.
- In Upload release assets (softprops/action-gh-release@v2):
  - `tag_name: ${{ github.event_name == 'workflow_dispatch' && inputs.tag || '' }}`
  - `overwrite: true`
- Confirmed `permissions: contents: write` already present at top.

Behavior for automatic release remains unchanged.

No local `act` validation performed; please rely on GitHub Actions runs. Attach CI logs/screenshots as needed.

Resolves #30.