### PR TITLE
fix(release): Normalize CRLF in checksum aggregation (#30)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -131,6 +131,8 @@ jobs:
           fi
           # Combine and sort lines for order-agnostic result
           cat "${files[@]}" | sort -u > dist/SHA256SUMS.txt
+          # Normalize potential CRLF line endings to LF to avoid stray \r in filenames
+          sed -i 's/\r$//' dist/SHA256SUMS.txt
           echo "Combined checksums count:" && wc -l dist/SHA256SUMS.txt
           # Ensure only one SHA256SUMS.txt exists at root
           if [[ ! -f dist/SHA256SUMS.txt ]]; then echo "Missing dist/SHA256SUMS.txt" >&2; exit 1; fi


### PR DESCRIPTION
This PR implements a minimal, idempotent fix to the Release Binaries workflow to make the Attach-to-Release step resilient to CRLF line endings that may appear in checksum files.

Scope
- File: `.github/workflows/release.yml`
- Job: Attach to Release (post-download/prepare phase)
- Approach: After generating `dist/SHA256SUMS.txt`, normalize line endings using `sed -i 's/\r$//' dist/SHA256SUMS.txt`.
- Keeps artifact names, matrix outputs, assertions, and diff checks intact.

Why
- Run #10 failed due to stray `\r` characters in filenames parsed from checksum files. Normalizing the combined checksum file resolves this without altering behavior when there are no CRLFs.

Acceptance
- References #30. CI passed on the PR branch (CI run #41). The release workflow can be re-dispatched for tag `v0.1.3` with Attach-to-Release succeeding post-merge.
