### PR TITLE
release: add pre-matrix tag guard for workflow_dispatch (fixes #35)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,13 +9,50 @@ on:
   workflow_dispatch:
     inputs:
       tag:
-        description: "Tag to release"
+        description: "Existing tag to release (e.g., v0.1.3). Must already exist in this repo."
         required: true
         type: string
 
 jobs:
+  guard:
+    name: Validate Tag (pre-matrix)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Verify workflow_dispatch tag exists
+        if: github.event_name == 'workflow_dispatch'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          RAW_TAG: ${{ inputs.tag }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          TAG="$RAW_TAG"
+          # Normalize potential refs/tags/ prefix from input
+          TAG="${TAG#refs/tags/}"
+          if [[ -z "$TAG" ]]; then
+            echo "Input 'tag' is required but empty. Provide a tag like 'v0.1.3'." >&2
+            exit 1
+          fi
+          echo "Validating tag exists: $TAG"
+          # Check exact tag ref via GitHub API
+          status=$(curl -sS -o /dev/null -w "%{http_code}" \
+            -H "Authorization: Bearer $GITHUB_TOKEN" \
+            -H "Accept: application/vnd.github+json" \
+            "https://api.github.com/repos/$REPO/git/refs/tags/$TAG")
+          if [[ "$status" != "200" ]]; then
+            echo "Tag '$TAG' was not found in $REPO (HTTP $status)." >&2
+            echo "Action required: Create the tag or specify a valid existing tag." >&2
+            echo "Examples:" >&2
+            echo "  git fetch --tags" >&2
+            echo "  git tag -a $TAG -m 'Release $TAG' && git push origin $TAG" >&2
+            exit 1
+          fi
+          echo "Tag '$TAG' exists. Proceeding."
+
   build:
     name: Build Artifacts
+    needs: guard
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
Implements issue #35 by adding an early guard job in the Release Binaries workflow to validate the `workflow_dispatch` input tag exists before starting the matrix builds.

Changes
- .github/workflows/release.yml
  - Add `guard` job that checks the provided tag via GitHub API and fails fast with a clear message if missing.
  - Update dispatch input description to clarify required existing tag (e.g., v0.1.3).
  - Make `build` job depend on `guard` to ensure early failure.

Behavior
- If a non-existent tag is provided when running via `workflow_dispatch`, the guard job fails with an actionable error and the matrix jobs do not start.
- If a valid tag is provided, the workflow proceeds as before.
- Normal release events (on: release: published) continue to work unchanged.

Notes
- Permissions remain unchanged; guard job uses the default GITHUB_TOKEN for a read-only API check.

Acceptance
- Single branch and PR named `issue-35-tag-guard`.
- Please monitor CI and share the commit SHA if any adjustments are needed. Closes #35.