### PR TITLE
fix(ci): rustfmt and release checksum line-ending normalization (#41)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -167,9 +167,14 @@ jobs:
             exit 1
           fi
           # Combine and sort lines for order-agnostic result
-          cat "${files[@]}" | sort -u > dist/SHA256SUMS.txt
-          # Normalize potential CRLF line endings to LF to avoid stray \r in filenames
-          sed -i 's/\r$//' dist/SHA256SUMS.txt
+          # Normalize CRLF to LF then combine and sort uniquely
+          tmp_combined=$(mktemp)
+          for f in "${files[@]}"; do
+            # Use sed portable in-place via temp file to strip CR prior to concat
+            sed 's/\r$//' "$f" >> "$tmp_combined"
+          done
+          sort -u "$tmp_combined" > dist/SHA256SUMS.txt
+          rm -f "$tmp_combined"
           echo "Combined checksums count:" && wc -l dist/SHA256SUMS.txt
           # Ensure only one SHA256SUMS.txt exists at root
           if [[ ! -f dist/SHA256SUMS.txt ]]; then echo "Missing dist/SHA256SUMS.txt" >&2; exit 1; fi
@@ -209,7 +214,8 @@ jobs:
             exit 1
           fi
           # Compare filenames in checksums vs actual binaries
-          sort <(awk '{print $2}' dist/SHA256SUMS.txt | xargs -n1 basename | sort -u) -o /tmp/check_names.txt
+          # Strip any stray CRs from combined file before extracting names
+          awk '{print $2}' dist/SHA256SUMS.txt | sed 's/\r$//' | xargs -n1 basename | sort -u -o /tmp/check_names.txt
           sort <(for b in "${bins[@]}"; do basename "$b"; done | sort -u) -o /tmp/bin_names.txt
           if ! diff -u /tmp/bin_names.txt /tmp/check_names.txt; then
             echo "Mismatch between binaries and checksum entries" >&2

--- a/src/server.rs
+++ b/src/server.rs
@@ -6,8 +6,8 @@ use log::{debug, info};
 // use reqwest::header::HeaderMap; // not needed currently
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
-use std::io::{self, BufRead, BufReader, Write};
 use std::fs::{File, OpenOptions};
+use std::io::{self, BufRead, BufReader, Write};
 use std::sync::{Mutex, OnceLock};
 
 // Minimal diagnostics helper: writes to stderr and optionally to a file if MCP_DIAG_LOG is set.
@@ -123,7 +123,10 @@ pub fn run_stdio_server() -> anyhow::Result<()> {
     }));
 
     // Diagnostics for startup and handshake
-    diag!("stdio server ready; NDJSON mode; protocol={}", PROTOCOL_VERSION);
+    diag!(
+        "stdio server ready; NDJSON mode; protocol={}",
+        PROTOCOL_VERSION
+    );
 
     let mut line = String::new();
     loop {
@@ -134,8 +137,14 @@ pub fn run_stdio_server() -> anyhow::Result<()> {
             break;
         }
         let raw = line.trim_end_matches(['\r', '\n']).to_string();
-        if raw.is_empty() { continue; }
-        diag!("stdin line bytes={} first100={}", raw.len(), &raw.chars().take(100).collect::<String>());
+        if raw.is_empty() {
+            continue;
+        }
+        diag!(
+            "stdin line bytes={} first100={}",
+            raw.len(),
+            &raw.chars().take(100).collect::<String>()
+        );
 
         let req: Result<Request, _> = serde_json::from_str(&raw);
         let Some(request) = req.ok() else {

--- a/tests/actions_integration.rs
+++ b/tests/actions_integration.rs
@@ -12,7 +12,11 @@ fn run_with_env(req: &serde_json::Value, envs: &[(&str, &str)]) -> anyhow::Resul
     let assert = cmd
         .arg("--log-level")
         .arg("warn")
-        .write_stdin({ let mut b = Vec::new(); writeln!(b, "{}", input).unwrap(); b })
+        .write_stdin({
+            let mut b = Vec::new();
+            writeln!(b, "{}", input).unwrap();
+            b
+        })
         .assert();
     let output = String::from_utf8(assert.get_output().stdout.clone()).unwrap();
     Ok(output)

--- a/tests/issues_integration.rs
+++ b/tests/issues_integration.rs
@@ -11,7 +11,11 @@ fn run_with_env(req: &serde_json::Value, envs: &[(&str, &str)]) -> anyhow::Resul
     let assert = cmd
         .arg("--log-level")
         .arg("warn")
-        .write_stdin({ let mut b = Vec::new(); writeln!(b, "{}", input).unwrap(); b })
+        .write_stdin({
+            let mut b = Vec::new();
+            writeln!(b, "{}", input).unwrap();
+            b
+        })
         .assert();
     let output = String::from_utf8(assert.get_output().stdout.clone()).unwrap();
     Ok(output)

--- a/tests/prs_integration.rs
+++ b/tests/prs_integration.rs
@@ -11,7 +11,11 @@ fn run_with_env(req: &serde_json::Value, envs: &[(&str, &str)]) -> anyhow::Resul
     let assert = cmd
         .arg("--log-level")
         .arg("warn")
-        .write_stdin({ let mut b = Vec::new(); writeln!(b, "{}", input).unwrap(); b })
+        .write_stdin({
+            let mut b = Vec::new();
+            writeln!(b, "{}", input).unwrap();
+            b
+        })
         .assert();
     let output = String::from_utf8(assert.get_output().stdout.clone()).unwrap();
     Ok(output)

--- a/tests/prs_more_integration.rs
+++ b/tests/prs_more_integration.rs
@@ -11,7 +11,11 @@ fn run_with_env(req: &serde_json::Value, envs: &[(&str, &str)]) -> anyhow::Resul
     let assert = cmd
         .arg("--log-level")
         .arg("warn")
-        .write_stdin({ let mut b = Vec::new(); writeln!(b, "{}", input).unwrap(); b })
+        .write_stdin({
+            let mut b = Vec::new();
+            writeln!(b, "{}", input).unwrap();
+            b
+        })
         .assert();
     let output = String::from_utf8(assert.get_output().stdout.clone()).unwrap();
     Ok(output)

--- a/tests/rest_pagination_and_rate.rs
+++ b/tests/rest_pagination_and_rate.rs
@@ -11,7 +11,11 @@ fn run_with_env(req: &serde_json::Value, envs: &[(&str, &str)]) -> anyhow::Resul
     let assert = cmd
         .arg("--log-level")
         .arg("warn")
-        .write_stdin({ let mut b = Vec::new(); writeln!(b, "{}", input).unwrap(); b })
+        .write_stdin({
+            let mut b = Vec::new();
+            writeln!(b, "{}", input).unwrap();
+            b
+        })
         .assert();
     let output = String::from_utf8(assert.get_output().stdout.clone()).unwrap();
     Ok(output)


### PR DESCRIPTION
This PR addresses Issue #41 by fixing CI fmt failures and stabilizing the Release Binaries workflow.

Changes:
- Format code to satisfy `cargo fmt --all -- --check`.
- Normalize CRLF line endings when combining per-target checksum files in the Release workflow, and ensure filename extraction is CR-safe.

Why:
- CI `fmt` job on `main` was failing due to rustfmt diffs in server.rs and tests.
- Release Binaries job mismatched checksum filename lists on Windows due to CRLF endings sneaking into the combined file.

Notes:
- No functional changes beyond formatting and line-ending normalization.
- References: closes #41.

Please monitor CI and release workflows. After merge, trigger Release Binaries via `workflow_dispatch` with an existing tag to validate end-to-end success.