### PR TITLE
feat(registry): add server.json for MCP Registry

### DIFF
--- a/server.json
+++ b/server.json
@@ -1,0 +1,54 @@
+{
+  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-09-29/server.schema.json",
+  "name": "io.github.hautechai/github-mcp",
+  "title": "GitHub MCP Server",
+  "description": "Agent-optimized GitHub MCP server over stdio for repository and issue workflows.",
+  "version": "0.2.0",
+  "websiteUrl": "https://github.com/HautechAI/github-mcp",
+  "repository": {
+    "url": "https://github.com/HautechAI/github-mcp",
+    "source": "github"
+  },
+  "packages": [
+    {
+      "registryType": "mcpb",
+      "registryBaseUrl": "https://github.com",
+      "identifier": "https://github.com/HautechAI/github-mcp/releases/download/v0.2.0/github-mcp-x86_64-unknown-linux-gnu",
+      "version": "0.2.0",
+      "fileSha256": "c63aa07b0feb8fb4ed070f1f8bdfa0236f028458639bf7148508d08f702e3602",
+      "transport": { "type": "stdio" }
+    },
+    {
+      "registryType": "mcpb",
+      "registryBaseUrl": "https://github.com",
+      "identifier": "https://github.com/HautechAI/github-mcp/releases/download/v0.2.0/github-mcp-aarch64-unknown-linux-gnu",
+      "version": "0.2.0",
+      "fileSha256": "989a32c89be656851c728780fd24dbde4af502493a09ce17af2d63d3272bed76",
+      "transport": { "type": "stdio" }
+    },
+    {
+      "registryType": "mcpb",
+      "registryBaseUrl": "https://github.com",
+      "identifier": "https://github.com/HautechAI/github-mcp/releases/download/v0.2.0/github-mcp-x86_64-apple-darwin",
+      "version": "0.2.0",
+      "fileSha256": "b508adca27761bf8887088e9f9ba33a9679d62da5262bcf532be2bfb2a209b98",
+      "transport": { "type": "stdio" }
+    },
+    {
+      "registryType": "mcpb",
+      "registryBaseUrl": "https://github.com",
+      "identifier": "https://github.com/HautechAI/github-mcp/releases/download/v0.2.0/github-mcp-aarch64-apple-darwin",
+      "version": "0.2.0",
+      "fileSha256": "4fb65ed2c8d2916bb99ae1bdd710809e954b927e725a3bc6f4c0749d10293a9e",
+      "transport": { "type": "stdio" }
+    },
+    {
+      "registryType": "mcpb",
+      "registryBaseUrl": "https://github.com",
+      "identifier": "https://github.com/HautechAI/github-mcp/releases/download/v0.2.0/github-mcp-x86_64-pc-windows-msvc.exe",
+      "version": "0.2.0",
+      "fileSha256": "120ccf8c38f377fe637fa662f5aaf6a0ed8c95ba9fd1bd011dbfff3f4c852677",
+      "transport": { "type": "stdio" }
+    }
+  ]
+}


### PR DESCRIPTION
This PR adds server.json at the repository root to enable MCP Registry publishing for the GitHub MCP server.

- Source: Issue #54 (Proposed server.json)
- Version: 0.2.0 (MCPB distribution via GitHub Releases)

Validation
- Tool: mcp-publisher (latest release v1.2.3)
- Command attempted: `mcp-publisher validate --file ./server.json`
  - The currently available CLI does not expose `validate`; usage lists only: init, login, logout, publish.
- Fallback attempted: `mcp-publisher publish --dry-run --file ./server.json`
  - Result: the CLI requires authentication even for `--dry-run`, so validation could not be executed in this environment without credentials.

Observed output
```
MCP Registry Publisher Tool

Usage:
  mcp-publisher <command> [arguments]

Commands:
  init          Create a server.json file template
  login         Authenticate with the registry
  logout        Clear saved authentication
  publish       Publish server.json to the registry

Use 'mcp-publisher <command> --help' for more information about a command.
```

and for dry-run:
```
Error: not authenticated. Run 'mcp-publisher login <method>' first
```

Next steps
- Maintainer: please run the validation locally and paste the output here and in Issue #54.
  - Preferred: `mcp-publisher validate --file ./server.json` (if your build provides it), else `mcp-publisher publish --dry-run --file ./server.json` after `mcp-publisher login`.
- If validation errors are reported, I will minimally adjust `server.json` to satisfy the schema and official registry requirements.

Closes #54.
