### PR TITLE
Output shaping: hide rate by default; opt-in via _include_rate; conditional meta/pagination (fix #74)

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,6 +168,12 @@ Notes
   - GraphQL `rateLimit` is included where feasible without complicating queries; some queries may still omit it.
   - REST pagination relies on Link headers; when GitHub omits Link for small result sets, `has_more` may be false with no `next_cursor`.
 
+Output shaping
+- Default behavior aims for minimal payloads:
+  - When a result is not paginated, pagination fields are hidden and the `meta` object may be omitted entirely.
+  - Rate limit metadata is excluded by default.
+- Opt-in rate metadata per call by adding `_include_rate: true` to the top-level tool arguments. When set, `meta.rate` is included; pagination keys are included only when relevant.
+
 MCP response envelope (breaking change)
 - tools/call results are wrapped:
   - `content`: array with one `{type:"text", text:"..."}` block for human-friendly display.

--- a/README.md
+++ b/README.md
@@ -174,6 +174,31 @@ Output shaping
   - Rate limit metadata is excluded by default.
 - Opt-in rate metadata per call by adding `_include_rate: true` to the top-level tool arguments. When set, `meta.rate` is included; pagination keys are included only when relevant.
 
+Example
+- Request (include rate):
+```
+{"jsonrpc":"2.0","method":"tools/call","id":1,
+ "params":{"name":"list_workflow_runs_light",
+           "arguments":{"owner":"octo","repo":"hello","per_page":30,"_include_rate":true}}}
+```
+- Response (excerpt):
+```
+{
+  "result": {
+    "content": [{"type":"text","text":"0 workflow runs"}],
+    "structuredContent": {
+      "items": [],
+      "meta": {
+        "has_more": true,
+        "next_cursor": "...",
+        "rate": {"remaining": 4999, "used": 1, "reset_at": "..."}
+      }
+    }
+  }
+}
+```
+When `_include_rate` is omitted or `false`, `meta.rate` is omitted. If `has_more` is false, `has_more` and `next_cursor` are also omitted and `meta` may be removed entirely.
+
 MCP response envelope (breaking change)
 - tools/call results are wrapped:
   - `content`: array with one `{type:"text", text:"..."}` block for human-friendly display.

--- a/docs/methods.md
+++ b/docs/methods.md
@@ -57,6 +57,11 @@ Common shapes
 | REST | X-RateLimit-Remaining, X-RateLimit-Used, X-RateLimit-Reset |
 | GraphQL | rateLimit { remaining, used, resetAt } |
 
+Output shaping
+- Lean by default: when a result is not paginated (has_more=false), has_more/next_cursor are omitted, and meta is removed entirely if no fields remain.
+- To include rate limit metadata, set a reserved per-call argument `_include_rate: true` at the top level of the tool arguments.
+- With `_include_rate: true`, meta is always present and includes `rate`; pagination keys appear only when `has_more` is true.
+
 ISSUES
 
 ## Tool: list_issues

--- a/src/mcp.rs
+++ b/src/mcp.rs
@@ -20,9 +20,15 @@ fn current_include_rate() -> bool {
 // - When include_rate is false: drop rate.
 // - Drop meta entirely if it becomes empty.
 fn prune_meta(structured: &mut Value, include_rate: bool) {
-    let Some(obj) = structured.as_object_mut() else { return; };
-    let Some(meta_val) = obj.get_mut("meta") else { return; };
-    let Some(meta_obj) = meta_val.as_object_mut() else { return; };
+    let Some(obj) = structured.as_object_mut() else {
+        return;
+    };
+    let Some(meta_val) = obj.get_mut("meta") else {
+        return;
+    };
+    let Some(meta_obj) = meta_val.as_object_mut() else {
+        return;
+    };
 
     let has_more = meta_obj
         .get("has_more")

--- a/src/mcp.rs
+++ b/src/mcp.rs
@@ -2,10 +2,8 @@ use serde_json::Value;
 use std::cell::Cell;
 
 // Thread-local flag indicating whether to include rate meta in outputs for the current tools/call.
-// Use non-const initializer to avoid raising MSRV; silence clippy on newer compilers.
-#[allow(clippy::missing_const_for_thread_local)]
+// Use a const initializer to satisfy clippy::missing_const_for_thread_local on Rust 1.90 (MSRV).
 thread_local! {
-    // Use const initializer to satisfy clippy::missing_const_for_thread_local (Rust 1.90).
     static INCLUDE_RATE: Cell<bool> = const { Cell::new(false) };
 }
 

--- a/src/mcp.rs
+++ b/src/mcp.rs
@@ -3,7 +3,8 @@ use std::cell::Cell;
 
 // Thread-local flag indicating whether to include rate meta in outputs for the current tools/call.
 thread_local! {
-    static INCLUDE_RATE: Cell<bool> = Cell::new(false);
+    // Use const initializer to satisfy clippy::missing_const_for_thread_local (Rust 1.90).
+    static INCLUDE_RATE: Cell<bool> = const { Cell::new(false) };
 }
 
 // Set the include-rate flag for the current thread (one tools/call invocation).

--- a/src/server.rs
+++ b/src/server.rs
@@ -10,7 +10,7 @@ use serde_json::Value;
 
 use crate::config::Config;
 use crate::http;
-use crate::mcp::mcp_wrap;
+use crate::mcp::{mcp_wrap, set_include_rate};
 use crate::tools::*;
 
 // Minimal diagnostics helper: writes to stderr and optionally to a file if MCP_DIAG_LOG is set.
@@ -243,6 +243,13 @@ fn handle_tools_call(id: Option<Id>, params: Value) -> Response {
     let Ok(call) = parsed else {
         return rpc_error(id, -32602, "Invalid params", None);
     };
+    // Read reserved top-level flag for output shaping.
+    let include_rate = call
+        .arguments
+        .get("_include_rate")
+        .and_then(|v| v.as_bool())
+        .unwrap_or(false);
+    set_include_rate(include_rate);
     match call.name.as_str() {
         "ping" => {
             if !is_ping_enabled() {

--- a/tests/prs_more_integration.rs
+++ b/tests/prs_more_integration.rs
@@ -49,6 +49,10 @@ fn list_pr_comments_plain_happy() -> anyhow::Result<()> {
     assert!(out.contains("\"structuredContent\""));
     assert!(out.contains("\"items\""));
     assert!(out.contains("\"author_login\":\"alice\""));
+    // No pagination, so meta should be pruned entirely by default
+    let v: serde_json::Value = serde_json::from_str(&out)?;
+    let sc = v.get("result").and_then(|r| r.get("structuredContent")).cloned().unwrap_or_default();
+    assert!(sc.get("meta").is_none(), "expected meta to be omitted when has_more=false and include_rate not requested: {}", sc);
     Ok(())
 }
 

--- a/tests/prs_more_integration.rs
+++ b/tests/prs_more_integration.rs
@@ -54,12 +54,10 @@ fn list_pr_comments_plain_happy() -> anyhow::Result<()> {
     let sc = v
         .get("result")
         .and_then(|r| r.get("structuredContent"))
-        .cloned()
-        .unwrap_or_default();
+        .and_then(|sc| sc.as_object());
     assert!(
-        sc.get("meta").is_none(),
-        "expected meta to be omitted when has_more=false and include_rate not requested: {}",
-        sc
+        sc.and_then(|o| o.get("meta")).is_none(),
+        "expected meta to be omitted when has_more=false and include_rate not requested"
     );
     Ok(())
 }

--- a/tests/prs_more_integration.rs
+++ b/tests/prs_more_integration.rs
@@ -51,8 +51,16 @@ fn list_pr_comments_plain_happy() -> anyhow::Result<()> {
     assert!(out.contains("\"author_login\":\"alice\""));
     // No pagination, so meta should be pruned entirely by default
     let v: serde_json::Value = serde_json::from_str(&out)?;
-    let sc = v.get("result").and_then(|r| r.get("structuredContent")).cloned().unwrap_or_default();
-    assert!(sc.get("meta").is_none(), "expected meta to be omitted when has_more=false and include_rate not requested: {}", sc);
+    let sc = v
+        .get("result")
+        .and_then(|r| r.get("structuredContent"))
+        .cloned()
+        .unwrap_or_default();
+    assert!(
+        sc.get("meta").is_none(),
+        "expected meta to be omitted when has_more=false and include_rate not requested: {}",
+        sc
+    );
     Ok(())
 }
 


### PR DESCRIPTION
Implements issue #74.

- Centralizes output shaping just before MCP envelope wrapping
- Excludes meta.rate by default; include only with `_include_rate: true`
- Hides has_more and next_cursor when has_more is false
- Hides meta entirely when not paginated and rate not requested
- Adds tests for REST and GraphQL across include_rate × has_more scenarios
- Updates README and docs/methods.md

All changes are scoped to this branch and this single PR for the issue.